### PR TITLE
call mutex on account loading error to avoid deadlock

### DIFF
--- a/src/stellar_service/stellar.ts
+++ b/src/stellar_service/stellar.ts
@@ -67,10 +67,10 @@ export class StellarService {
     const unlock = await this.mutex.lock();
 
     // Load and validate destination account
-    await this.loadAccount(destination, server);
+    await this.loadAccount(destination, server, unlock);
 
     // Load source account
-    let sourceAccount = await this.loadAccount(keys.publicKey(), server);
+    let sourceAccount = await this.loadAccount(keys.publicKey(), server, unlock);
 
     try {
       const feeStatsResponse = await server.feeStats();
@@ -204,11 +204,14 @@ export class StellarService {
   private async loadAccount(
     accountId: string,
     server: Server,
+    mutexUnlock: () => void = () => {},
   ): Promise<AccountResponse> {
     let account: AccountResponse;
+
     try {
       account = await server.loadAccount(accountId);
     } catch (error) {
+      mutexUnlock();
       if (error instanceof NotFoundError) {
         throw new StellarAccountError(
           `The Stellar account ${accountId} does not exist!`,


### PR DESCRIPTION
Issue #14 

As described in the issue, right after the `StellarAccountError` (slack message [here](https://satoshipay.slack.com/archives/C05PW684QK1/p1708000310975529)) the service got stuck and did not allow other tests to continue or even start.

The behavior makes sense, given that before we were returning an error from the `transfer` [function](https://github.com/pendulum-chain/spacewalk-testing-service/compare/testing-service-stuck-on-load-account-error?expand=1#diff-e01c018d1a549695bf323a0ee4db3d36bef87daf0d2e0377f234fa9f6af99fdfL212) without releasing the lock, which lead to a deadlock in which all test processes where waiting at the point of making a stellar transfer.

### Notes
It is still unclear what caused the load account error in the first place, I was not able to replicate it.