### PR TITLE
Try reconnecting api for bad signature errors

### DIFF
--- a/src/test/test.ts
+++ b/src/test/test.ts
@@ -3,7 +3,7 @@ import { StellarService } from "../stellar_service/stellar.js";
 import { Config, NetworkConfig, TestedVault } from "../config.js";
 import { EventListener } from "../vault_service/event_listener.js";
 import { VaultService } from "../vault_service/vault.js";
-import { ApiManager, API } from "../vault_service/api.js";
+import { ApiManager, ApiComponents } from "../vault_service/api.js";
 import { Asset } from "stellar-sdk";
 import {
   serializeVaultId,
@@ -103,7 +103,7 @@ export class Test {
       this.apiManager,
       network.name,
     );
-    const api = await this.apiManager.getApi(network.name);
+    const apiComponents = await this.apiManager.getApiComponents(network.name);
 
     // Create issue request and wait for its confirmation event
     let issueRequestEvent = await vaultService.requestIssue(uri, bridgeAmount);
@@ -139,7 +139,7 @@ export class Test {
     this.testStages.set(serializedVaultID, TestStage.STELLAR_PAYMENT_COMPLETED);
 
     //Wait for issue execution
-    const eventListener = EventListener.getEventListener(api.api);
+    const eventListener = EventListener.getEventListener(apiComponents.api);
     const maxWaitingTimeMs =
       this.instanceConfig.getCompletionWindowMinutes() * 60 * 1000;
     const issueEvent = await eventListener.waitForIssueExecuteEvent(
@@ -180,7 +180,7 @@ export class Test {
         network.name
       } with amount ${amountIssued}`,
     );
-    let api = await this.apiManager.getApi(network.name);
+    let api = await this.apiManager.getApiComponents(network.name);
 
     // Test values
     const serializedVaultID = serializeVaultId(vault.id, network.name);

--- a/src/test/test.ts
+++ b/src/test/test.ts
@@ -94,13 +94,11 @@ export class Test {
         vault.id,
       )} on network ${network.name}`,
     );
-    let api = await this.apiManager.getApi(network.name);
-
     // Test values
     const serializedVaultID = serializeVaultId(vault.id, network.name);
     let bridgeAmount = this.instanceConfig.getBridgedAmount();
     let uri = this.instanceConfig.getSecretForNetwork(network.name);
-    let vaultService = new VaultService(vault.id, api);
+    let vaultService = new VaultService(vault.id, this.apiManager, network);
 
     // Create issue request and wait for its confirmation event
     let issueRequestEvent = await vaultService.requestIssue(uri, bridgeAmount);

--- a/src/test/test.ts
+++ b/src/test/test.ts
@@ -98,7 +98,12 @@ export class Test {
     const serializedVaultID = serializeVaultId(vault.id, network.name);
     let bridgeAmount = this.instanceConfig.getBridgedAmount();
     let uri = this.instanceConfig.getSecretForNetwork(network.name);
-    let vaultService = new VaultService(vault.id, this.apiManager, network);
+    let vaultService = new VaultService(
+      vault.id,
+      this.apiManager,
+      network.name,
+    );
+    const api = await this.apiManager.getApi(network.name);
 
     // Create issue request and wait for its confirmation event
     let issueRequestEvent = await vaultService.requestIssue(uri, bridgeAmount);
@@ -183,7 +188,11 @@ export class Test {
     let stellarPkBytes = this.instanceConfig.getStellarPublicKeyRaw(
       network.stellarMainnet,
     );
-    let vaultService = new VaultService(vault.id, api);
+    let vaultService = new VaultService(
+      vault.id,
+      this.apiManager,
+      network.name,
+    );
 
     // Create redeem request and expect it's corresponding event
     let redeemRequestEvent = await vaultService.requestRedeem(

--- a/src/vault_service/api.ts
+++ b/src/vault_service/api.ts
@@ -76,7 +76,7 @@ class ApiManager {
           }
 
           apiComponents = await this.connectApi(wss);
-          this.apiComponentInstanceDict["network"] = apiComponents;
+          this.apiComponentInstanceDict[network] = apiComponents;
           return await apiCall(apiComponents.api);
         } catch (retryError) {
           throw retryError;

--- a/src/vault_service/vault.ts
+++ b/src/vault_service/vault.ts
@@ -17,7 +17,7 @@ import {
 export class VaultService {
   public vaultId: VaultID;
   private apiManager: ApiManager;
-  private network: string;
+  private readonly network: string;
 
   constructor(vaultId: VaultID, apiManager: ApiManager, network: string) {
     this.vaultId = vaultId;

--- a/src/vault_service/vault.ts
+++ b/src/vault_service/vault.ts
@@ -37,21 +37,20 @@ export class VaultService {
       )}`,
     );
 
-    return new Promise<IIssueRequest>(async (resolve, reject) => {
-      const apiComponents = await this.apiManager.getApiComponents(
-        this.network,
-      );
+    const apiComponents = await this.apiManager.getApiComponents(this.network);
 
-      const keyring = new Keyring({ type: "sr25519" });
-      keyring.setSS58Format(apiComponents.ss58Format);
-      const origin = keyring.addFromUri(uri);
+    const keyring = new Keyring({ type: "sr25519" });
+    keyring.setSS58Format(apiComponents.ss58Format);
+    const origin = keyring.addFromUri(uri);
 
-      const release = await apiComponents.mutex.lock(origin.address);
+    const release = await apiComponents.mutex.lock(origin.address);
 
-      const nonce = await this.apiManager.executeApiCall(this.network, (api) =>
-        api.rpc.system.accountNextIndex(origin.publicKey),
-      );
-      await this.apiManager.executeApiCall(this.network, (api) =>
+    const nonce = await this.apiManager.executeApiCall(this.network, (api) =>
+      api.rpc.system.accountNextIndex(origin.publicKey),
+    );
+
+    return new Promise<IIssueRequest>((resolve, reject) => {
+      this.apiManager.executeApiCall(this.network, (api) =>
         api.tx.issue
           .requestIssue(amount, this.vaultId)
           .signAndSend(origin, { nonce }, (submissionResult) => {

--- a/src/vault_service/vault.ts
+++ b/src/vault_service/vault.ts
@@ -6,7 +6,7 @@ import {
   parseEventIssueRequest,
   parseEventRedeemRequest,
 } from "./event_parsers.js";
-import { API } from "./api.js";
+import { API, ApiManager } from "./api.js";
 import {
   MissingInBlockEventError,
   TestDispatchError,
@@ -16,13 +16,15 @@ import {
 
 export class VaultService {
   public vaultId: VaultID;
-  private api: API;
+  private apiManager: ApiManager;
+  private network: string;
 
-  constructor(vaultId: VaultID, api: API) {
+  constructor(vaultId: VaultID, apiManager: ApiManager, network: string) {
     this.vaultId = vaultId;
     // Potentially validate the vault given the network,
     // validate the wrapped asset consistency, etc
-    this.api = api;
+    this.apiManager = apiManager;
+    this.network = network;
   }
 
   public async requestIssue(
@@ -36,82 +38,86 @@ export class VaultService {
     );
 
     return new Promise<IIssueRequest>(async (resolve, reject) => {
+      const api = await this.apiManager.getApi(this.network);
+
       const keyring = new Keyring({ type: "sr25519" });
-      keyring.setSS58Format(this.api.ss58Format);
+      keyring.setSS58Format(api.ss58Format);
       const origin = keyring.addFromUri(uri);
 
-      const release = await this.api.mutex.lock(origin.address);
+      const release = await api.mutex.lock(origin.address);
 
-      const nonce = await this.api.api.rpc.system.accountNextIndex(
-        origin.publicKey,
+      const nonce = await this.apiManager.executeApiCall(this.network, (api) =>
+        api.rpc.system.accountNextIndex(origin.publicKey),
       );
-      await this.api.api.tx.issue
-        .requestIssue(amount, this.vaultId)
-        .signAndSend(origin, { nonce }, (submissionResult) => {
-          const { status, events, dispatchError, internalError } =
-            submissionResult;
+      await this.apiManager.executeApiCall(this.network, (api) =>
+        api.tx.issue
+          .requestIssue(amount, this.vaultId)
+          .signAndSend(origin, { nonce }, (submissionResult) => {
+            const { status, events, dispatchError, internalError } =
+              submissionResult;
 
-          if (status.isFinalized) {
-            console.log(
-              `Requested issue of ${amount} for vault ${prettyPrintVaultId(
-                this.vaultId,
-              )} with status ${status.type}`,
-            );
-
-            // Try to find a 'system.ExtrinsicFailed' event
-            const systemExtrinsicFailedEvent = events.find((record) => {
-              return (
-                record.event.section === "system" &&
-                record.event.method === "ExtrinsicFailed"
+            if (status.isFinalized) {
+              console.log(
+                `Requested issue of ${amount} for vault ${prettyPrintVaultId(
+                  this.vaultId,
+                )} with status ${status.type}`,
               );
-            });
 
-            if (dispatchError) {
-              return reject(
+              // Try to find a 'system.ExtrinsicFailed' event
+              const systemExtrinsicFailedEvent = events.find((record) => {
+                return (
+                  record.event.section === "system" &&
+                  record.event.method === "ExtrinsicFailed"
+                );
+              });
+
+              if (dispatchError) {
                 this.handleDispatchError(
                   dispatchError,
                   systemExtrinsicFailedEvent,
                   "Issue Request",
-                ),
-              );
-            }
+                ).then((error) => reject(error));
+              }
 
-            //find all issue events and filter the one that matches the requester
-            let issueEvents = events.filter((event: EventRecord) => {
-              return (
-                event.event.section.toLowerCase() === "issue" &&
-                event.event.method.toLowerCase() === "requestissue"
-              );
-            });
-
-            let event = issueEvents
-              .map((event) => parseEventIssueRequest(event))
-              .filter((event: IIssueRequest) => {
-                return event.requester === origin.address;
+              //find all issue events and filter the one that matches the requester
+              let issueEvents = events.filter((event: EventRecord) => {
+                return (
+                  event.event.section.toLowerCase() === "issue" &&
+                  event.event.method.toLowerCase() === "requestissue"
+                );
               });
 
-            if (event.length == 0) {
-              reject(
-                new MissingInBlockEventError(
-                  "No issue event found",
-                  "Issue Request Event",
-                ),
-              );
-            }
+              let event = issueEvents
+                .map((event) => parseEventIssueRequest(event))
+                .filter((event: IIssueRequest) => {
+                  return event.requester === origin.address;
+                });
 
-            //we should only find one event corresponding to the issue request
-            if (event.length != 1) {
-              reject(
-                new Error("Inconsistent amount of issue events for account"),
-              );
+              if (event.length == 0) {
+                reject(
+                  new MissingInBlockEventError(
+                    "No issue event found",
+                    "Issue Request Event",
+                  ),
+                );
+              }
+
+              //we should only find one event corresponding to the issue request
+              if (event.length != 1) {
+                reject(
+                  new Error("Inconsistent amount of issue events for account"),
+                );
+              }
+              resolve(event[0]);
             }
-            resolve(event[0]);
-          }
-        })
-        .catch((error) => {
-          reject(new RpcError(error.message, "Issue Request", origin.address));
-        })
-        .finally(() => release());
+          })
+          .catch((error) => {
+            reject(
+              new RpcError(error.message, "Issue Request", origin.address),
+            );
+          })
+          .finally(() => release()),
+      );
     });
   }
 
@@ -120,95 +126,99 @@ export class VaultService {
     amount: number,
     stellarPkBytes: Buffer,
   ): Promise<IRedeemRequest> {
-    return new Promise<IRedeemRequest>(async (resolve, reject) => {
-      const keyring = new Keyring({ type: "sr25519" });
-      keyring.setSS58Format(this.api.ss58Format);
-      const origin = keyring.addFromUri(uri);
+    const api = await this.apiManager.getApi(this.network);
 
-      const release = await this.api.mutex.lock(origin.address);
-      const nonce = await this.api.api.rpc.system.accountNextIndex(
-        origin.publicKey,
-      );
-      await this.api.api.tx.redeem
-        .requestRedeem(amount, stellarPkBytes, this.vaultId)
-        .signAndSend(origin, { nonce }, (submissionResult) => {
-          const { status, events, dispatchError } = submissionResult;
+    const keyring = new Keyring({ type: "sr25519" });
+    keyring.setSS58Format(api.ss58Format);
+    const origin = keyring.addFromUri(uri);
 
-          if (status.isFinalized) {
-            console.log(
-              `Requested redeem of ${amount} for vault ${prettyPrintVaultId(
-                this.vaultId,
-              )} with status ${status.type}`,
-            );
+    const release = await api.mutex.lock(origin.address);
+    const nonce = await this.apiManager.executeApiCall(this.network, (api) =>
+      api.rpc.system.accountNextIndex(origin.publicKey),
+    );
 
-            // Try to find a 'system.ExtrinsicFailed' event
-            const systemExtrinsicFailedEvent = events.find((record) => {
-              return (
-                record.event.section === "system" &&
-                record.event.method === "ExtrinsicFailed"
+    return new Promise<IRedeemRequest>((resolve, reject) => {
+      this.apiManager.executeApiCall(this.network, (api) =>
+        api.tx.redeem
+          .requestRedeem(amount, stellarPkBytes, this.vaultId)
+          .signAndSend(origin, { nonce }, (submissionResult) => {
+            const { status, events, dispatchError } = submissionResult;
+
+            if (status.isFinalized) {
+              console.log(
+                `Requested redeem of ${amount} for vault ${prettyPrintVaultId(
+                  this.vaultId,
+                )} with status ${status.type}`,
               );
-            });
 
-            if (dispatchError) {
-              return reject(
+              // Try to find a 'system.ExtrinsicFailed' event
+              const systemExtrinsicFailedEvent = events.find((record) => {
+                return (
+                  record.event.section === "system" &&
+                  record.event.method === "ExtrinsicFailed"
+                );
+              });
+
+              if (dispatchError) {
                 this.handleDispatchError(
                   dispatchError,
                   systemExtrinsicFailedEvent,
                   "Redeem Request",
-                ),
-              );
-            }
-            //find all redeem request events and filter the one that matches the requester
-            let redeemEvents = events.filter((event: EventRecord) => {
-              return (
-                event.event.section.toLowerCase() === "redeem" &&
-                event.event.method.toLowerCase() === "requestredeem"
-              );
-            });
-
-            let event = redeemEvents
-              .map((event) => parseEventRedeemRequest(event))
-              .filter((event: IRedeemRequest) => {
-                return event.redeemer === origin.address;
+                ).then((error) => reject(error));
+              }
+              //find all redeem request events and filter the one that matches the requester
+              let redeemEvents = events.filter((event: EventRecord) => {
+                return (
+                  event.event.section.toLowerCase() === "redeem" &&
+                  event.event.method.toLowerCase() === "requestredeem"
+                );
               });
 
-            if (event.length == 0) {
-              reject(
-                new MissingInBlockEventError(
-                  "No redeem event found",
-                  "Redeem Request Event",
-                ),
-              );
+              let event = redeemEvents
+                .map((event) => parseEventRedeemRequest(event))
+                .filter((event: IRedeemRequest) => {
+                  return event.redeemer === origin.address;
+                });
+
+              if (event.length == 0) {
+                reject(
+                  new MissingInBlockEventError(
+                    "No redeem event found",
+                    "Redeem Request Event",
+                  ),
+                );
+              }
+              //we should only find one event corresponding to the issue request
+              if (event.length != 1) {
+                reject(
+                  new Error(
+                    "Inconsistent amount of redeem request events for account",
+                  ),
+                );
+              }
+              resolve(event[0]);
             }
-            //we should only find one event corresponding to the issue request
-            if (event.length != 1) {
-              reject(
-                new Error(
-                  "Inconsistent amount of redeem request events for account",
-                ),
-              );
-            }
-            resolve(event[0]);
-          }
-        })
-        .catch((error) => {
-          reject(new RpcError(error.message, "Redeem Request", origin.address));
-        })
-        .finally(() => release());
+          })
+          .catch((error) => {
+            reject(
+              new RpcError(error.message, "Redeem Request", origin.address),
+            );
+          })
+          .finally(() => release()),
+      );
     });
   }
 
   // We first check if dispatchError is of type "module",
   // If not we either return ExtrinsicFailedError or Unknown dispatch error
-  handleDispatchError(
+  async handleDispatchError(
     dispatchError: any,
     systemExtrinsicFailedEvent: EventRecord | undefined,
     extrinsicCalled: string,
-  ): TestDispatchError | ExtrinsicFailedError {
+  ): Promise<TestDispatchError | ExtrinsicFailedError> {
     if (dispatchError?.isModule) {
-      const decoded = this.api.api.registry.findMetaError(
-        dispatchError.asModule,
-      );
+      const api = await this.apiManager.getApi(this.network);
+      const decoded = api.api.registry.findMetaError(dispatchError.asModule);
       const { docs, name, section, method } = decoded;
 
       return new TestDispatchError(


### PR DESCRIPTION
The implementation is based on the changes in https://github.com/pendulum-chain/faucet/pull/4.

- [x] Rename `API` to `ApiComponents` to make it less ambiguous with the polkadot.js API object
- [x] Add extra function to execute API calls. This function will check for errors with the the call and reinstantiate the API if necessary.

Closes #11.