### PR TITLE
Change tested vaults

### DIFF
--- a/config.json
+++ b/config.json
@@ -29,152 +29,6 @@
       ]
     },
     {
-      "name": "amplitude",
-      "wss": "wss://rpc-amplitude.pendulumchain.tech",
-      "stellarMainnet": true,
-      "testedVaults": [
-        {
-          "id": {
-            "accountId": "6mb5AuwinTp5BJ8hB2A2a71U2ZXu2jc4GBckuvp85Vy5nb1s",
-            "currencies": {
-              "collateral": {
-                "XCM": 0
-              },
-              "wrapped": {
-                "Stellar": {
-                  "AlphaNum4": {
-                    "code": "USDC",
-                    "issuer": "0x3b9911380efe988ba0a8900eb1cfe44f366f7dbe946bed077240f7f624df15c5"
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
-          "id": {
-            "accountId": "6n34uuJz9raainPkGfrVgrmj1Cb3Uxh8zbesCRYCz17GQCgJ",
-            "currencies": {
-              "collateral": {
-                "XCM": 0
-              },
-              "wrapped": {
-                "Stellar": {
-                  "AlphaNum4": {
-                    "code": "USDC",
-                    "issuer": "0x3b9911380efe988ba0a8900eb1cfe44f366f7dbe946bed077240f7f624df15c5"
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
-          "id": {
-            "accountId": "6kZGd35VLw37Fh8KZmoKq91KExVRg7fshXVnLYMzfatatt25",
-            "currencies": {
-              "collateral": {
-                "XCM": 0
-              },
-              "wrapped": {
-                "Stellar": "StellarNative"
-              }
-            }
-          }
-        },
-        {
-          "id": {
-            "accountId": "6iEjSzEPWvBkpFCLY4LHnwSDCYnwjvVvCH8MJkWHTfoEXMox",
-            "currencies": {
-              "collateral": {
-                "XCM": 0
-              },
-              "wrapped": {
-                "Stellar": {
-                  "AlphaNum4": {
-                    "code": "0x42524c00",
-                    "issuer": "0xeaac68d4d0e37b4c24c2536916e830735f032d0d6b2a1c8fca3bc5a25e083e3a"
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
-          "id": {
-            "accountId": "6mpGcpNdmKttMkQG42VGhq1fU2gofz4uXA3XeoPuNtrnqZLM",
-            "currencies": {
-              "collateral": {
-                "XCM": 0
-              },
-              "wrapped": {
-                "Stellar": {
-                  "AlphaNum4": {
-                    "code": "0x545a5300",
-                    "issuer": "0x34c94b2a4ba9e8b57b22547dcbb30f443c4cb02da3829a89aa1bd4780e4466ba"
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
-          "id": {
-            "accountId": "6k4C4GimGnri5BgTAWxKkUZhtnSagzK3TFKx1emofiNTq1Et",
-            "currencies": {
-              "collateral": {
-                "XCM": 0
-              },
-              "wrapped": {
-                "Stellar": {
-                  "AlphaNum4": {
-                    "code": "NGNC",
-                    "issuer": "0x241afadf31883f79972545fc64f3b5b0c95704c6fb4917474e42b0057841606b"
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
-          "id": {
-            "accountId": "6heFKGVJeMRMua1u3LgRCRJJKEkBoAPhdMnNGkpTWYJfGPnR",
-            "currencies": {
-              "collateral": {
-                "XCM": 0
-              },
-              "wrapped": {
-                "Stellar": {
-                  "AlphaNum4": {
-                    "code": "EURC",
-                    "issuer": "0x2112ee863867e4e219fe254c0918b00bc9ea400775bfc3ab4430971ce505877c"
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
-          "id": {
-            "accountId": "6jvAnyNWmtZSF5efLSxgx9awf4nn44r2Pbwuu8L3Ru5B77aN",
-            "currencies": {
-              "collateral": {
-                "XCM": 0
-              },
-              "wrapped": {
-                "Stellar": {
-                  "AlphaNum4": {
-                    "code": "AUDD",
-                    "issuer": "0xc5fbe9979e240552860221f4fe2f2219f35e40458b8b58fc32da520a154a561d"
-                  }
-                }
-              }
-            }
-          }
-        }
-      ]
-    },
-    {
       "name": "pendulum",
       "wss": "wss://rpc-pendulum.prd.pendulumchain.tech:443",
       "stellarMainnet": true,
@@ -361,6 +215,42 @@
                   "AlphaNum4": {
                     "code": "NGNC",
                     "issuer": "0x241afadf31883f79972545fc64f3b5b0c95704c6fb4917474e42b0057841606b"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "id": {
+            "accountId": "6bE2vjpLRkRNoVDqDtzokxE34QdSJC2fz7c87R9yCVFFDNWs",
+            "currencies": {
+              "collateral": {
+                "XCM": 10
+              },
+              "wrapped": {
+                "Stellar": {
+                  "AlphaNum4": {
+                    "code": "0x41525300",
+                    "issuer": "0xb04f8bff207a0b001aec7b7659a8d106e54e659cdf9533528f468e079628fba1"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "id": {
+            "accountId": "6eYGTQ8yqNZCdZppmkWfYwmHzv28oczyYXSLcPmhGAM3SbTV",
+            "currencies": {
+              "collateral": {
+                "XCM": 10
+              },
+              "wrapped": {
+                "Stellar": {
+                  "AlphaNum4": {
+                    "code": "0x50454e00",
+                    "issuer": "0x3931bdb4165f371c3b9aa9860c51a8277510033ff24c10364aa0a26a8128b0d0"
                   }
                 }
               }


### PR DESCRIPTION
This PR
-  removes all amplitude vaults from the automated testing
- adds two more vaults on Pendulum